### PR TITLE
Typo in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,3 @@
-
         __                                               
        |__|  ______ ____    ____    ____    _________  __
        |  | /  ___//  _ \  /    \ _/ ___\  /  ___/\  \/ /
@@ -23,7 +22,7 @@ npm install jsoncsv
 
 ``` coffeescript
 fs = require 'fs'
-csvjs = require 'jsoncsv'
+jsoncsv = require 'jsoncsv'
 
 COLUMNS = ['key1','key2','key3','action']
 


### PR DESCRIPTION
Fixed a really small transcription error in the example with the variable name for the jsoncsv module
